### PR TITLE
Support juju 3.4

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,36 +22,21 @@ jobs:
         python-version: ["3.8", "3.10"]
     with:
       python-version: ${{ matrix.python-version }}
-      tox-version: "<4"
       working-directory: ./src
 
   func:
-    name: Functional tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
+    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
     needs: lint-unit
     strategy:
       fail-fast: false
       matrix:
         include:
-          - juju-channel: '3.4/stable'
-            command: 'TEST_JUJU3=1 make functional'  # using TEST_JUJU3 due https://github.com/openstack-charmers/zaza/commit/af7eea953dd5d74d3d074fe67b5765dca3911ca6
-          - juju-channel: '2.9/stable'
-            command: 'make functional'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Setup Juju ${{ matrix.juju-channel }} LXD environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-          juju-channel: ${{ matrix.juju-channel }}
-      - name: Show juju information
-        run: |
-          juju version
-          juju controllers | grep Version -A 1 | awk '{print $9}'
-      - name: Run functional test
-        run: ${{ matrix.command }}
+          - juju-channel: "3.4/stable"
+            command: "TEST_JUJU3=1 make functional"  # using TEST_JUJU3 due https://github.com/openstack-charmers/zaza/commit/af7eea953dd5d74d3d074fe67b5765dca3911ca6
+    with:
+      command: ${{ matrix.command }}
+      juju-channel: ${{ matrix.juju-channel }}
+      nested-containers: false
+      provider: "lxd"
+      python-version: "3.10"
+      timeout-minutes: 120

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,19 +22,29 @@ jobs:
       working-directory: ./src
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
+    name: Functional tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
     needs: lint-unit
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - juju-channel: "3.1/stable"
-            command: "make functional"
-    with:
-      command: ${{ matrix.command }}
-      juju-channel: ${{ matrix.juju-channel }}
-      nested-containers: false
-      provider: "lxd"
-      python-version: "3.10"
-      timeout-minutes: 120
-      tox-version: "<4"
+        juju-channel: ['3.4/stable']
+        command: ['TEST_JUJU3=1 make functional']  # using TEST_JUJU3 due https://github.com/openstack-charmers/zaza/commit/af7eea953dd5d74d3d074fe67b5765dca3911ca6
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Setup Juju ${{ matrix.juju-channel }} LXD environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          juju-channel: ${{ matrix.juju-channel }}
+      - name: Show juju information
+        run: |
+          juju version
+          juju controllers | grep Version -A 1 | awk '{print $9}'
+      - name: Run functional test
+        run: ${{ matrix.command }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -33,8 +33,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        juju-channel: ['3.4/stable']
-        command: ['TEST_JUJU3=1 make functional']  # using TEST_JUJU3 due https://github.com/openstack-charmers/zaza/commit/af7eea953dd5d74d3d074fe67b5765dca3911ca6
+        include:
+          - juju-channel: '3.4/stable'
+            command: 'TEST_JUJU3=1 make functional'  # using TEST_JUJU3 due https://github.com/openstack-charmers/zaza/commit/af7eea953dd5d74d3d074fe67b5765dca3911ca6
+          - juju-channel: '2.9/stable'
+            command: 'make functional'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -46,7 +49,6 @@ jobs:
         with:
           provider: lxd
           juju-channel: ${{ matrix.juju-channel }}
-          lxd-channel: "5.20/stable"  # tmp fix until https://github.com/canonical/charmcraft/issues/1640
       - name: Show juju information
         run: |
           juju version

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,6 +9,10 @@ on:
       - "**.md"
       - "**.rst"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-unit:
     uses: canonical/bootstack-actions/.github/workflows/lint-unit.yaml@v2

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -42,6 +42,7 @@ jobs:
         with:
           provider: lxd
           juju-channel: ${{ matrix.juju-channel }}
+          lxd-channel: "5.20/stable"  # tmp fix until https://github.com/canonical/charmcraft/issues/1640
       - name: Show juju information
         run: |
           juju version

--- a/src/CONTRIB.md
+++ b/src/CONTRIB.md
@@ -49,9 +49,6 @@ make build
 charm build
 ```
 
-You can set various environment variables (e.g. JUJU_REPOSITORY, CHARM_BUILD_DIR) to build into 
-your desired directory. By default, the project will build into /tmp/charm-builds/duplicity. 
-
 ## Running Tests
 
 The following section will review running automated tests in the project.

--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -14,7 +14,6 @@ tags:
   # https://jujucharms.com/docs/stable/authors-charm-metadata
   - backup
 subordinate: true
-series: []
 provides:
   nrpe-external-master:
     interface: nrpe-external-master

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,3 +2,7 @@
 croniter
 pidfile
 fabric
+# NOTE(rgildein): The contextvars could not be installed without this requirement to be specified.
+setuptools>=42
+# NOTE(rgildein): The typing-extensions could not be installed without this requirement to be specified.
+flit-core>=3

--- a/src/tests/functional/requirements.txt
+++ b/src/tests/functional/requirements.txt
@@ -1,4 +1,4 @@
 flake8
 mock
-git+https://github.com/rgildein/zaza.git@chore/no-ref/fix-action-object#egg=zaza
+git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza
 python-openstackclient

--- a/src/tests/functional/requirements.txt
+++ b/src/tests/functional/requirements.txt
@@ -1,4 +1,4 @@
 flake8
 mock
-git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+git+https://github.com/rgildein/zaza.git@chore/no-ref/fix-action-object#egg=zaza
 python-openstackclient

--- a/src/tests/functional/requirements.txt
+++ b/src/tests/functional/requirements.txt
@@ -1,4 +1,4 @@
 flake8
 mock
-git+https://github.com/openstack-charmers/zaza.git@libjuju-3.1#egg=zaza
+git+https://github.com/openstack-charmers/zaza.git#egg=zaza
 python-openstackclient

--- a/src/tests/functional/tests/bundles/base.yaml
+++ b/src/tests/functional/tests/bundles/base.yaml
@@ -11,7 +11,7 @@ applications:
     charm: nrpe
 
   duplicity:
-    charm: /tmp/charm-builds/duplicity
+    charm: duplicity
     options:
       backend: file
       remote_backup_url: 'file:///home/ubuntu/somedir'

--- a/src/tests/functional/tests/configure.py
+++ b/src/tests/functional/tests/configure.py
@@ -22,8 +22,7 @@ def set_ssh_password_access_on_backup_host():
     """Configure ssh access with password on backup host."""
     backup_host_unit = _get_unit("backup-host")
     command = (
-        "sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' "
-        "/etc/ssh/sshd_config && "
+        'echo "PasswordAuthentication yes" > 01-test-settings.conf &&'
         "service sshd reload"
     )
     result = zaza.model.run_on_unit(backup_host_unit.name, command, timeout=15)

--- a/src/tests/functional/tests/configure.py
+++ b/src/tests/functional/tests/configure.py
@@ -22,8 +22,8 @@ def set_ssh_password_access_on_backup_host():
     """Configure ssh access with password on backup host."""
     backup_host_unit = _get_unit("backup-host")
     command = (
-        'echo "PasswordAuthentication yes" > 01-test-settings.conf &&'
-        "service sshd reload"
+        'echo "PasswordAuthentication yes" > '
+        "/etc/ssh/sshd_config.d/01-test-settings.conf && service sshd reload"
     )
     result = zaza.model.run_on_unit(backup_host_unit.name, command, timeout=15)
     _check_run_result(result)

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -22,6 +22,7 @@ passenv =
   SNAP_HTTP_PROXY
   SNAP_HTTPS_PROXY
   OS_*
+  TEST_*
 
 [testenv:lint]
 commands =
@@ -76,4 +77,5 @@ deps = -r{toxinidir}/tests/unit/requirements.txt
 [testenv:func]
 changedir = {toxinidir}/tests/functional
 commands = functest-run-suite {posargs:--keep-faulty-model}
-deps = -r {toxinidir}/tests/functional/requirements.txt
+deps =
+  -r {toxinidir}/tests/functional/requirements.txt

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -21,16 +21,7 @@ passenv =
   NO_PROXY
   SNAP_HTTP_PROXY
   SNAP_HTTPS_PROXY
-  OS_REGION_NAME
-  OS_AUTH_VERSION
-  OS_AUTH_URL
-  OS_PROJECT_DOMAIN_NAME
-  OS_USERNAME
-  OS_PASSWORD
-  OS_PROJECT_ID
-  OS_USER_DOMAIN_NAME
-  OS_PROJECT_NAME
-  OS_IDENTITY_API_VERSION
+  OS_*
 
 [testenv:lint]
 commands =
@@ -84,5 +75,5 @@ deps = -r{toxinidir}/tests/unit/requirements.txt
 
 [testenv:func]
 changedir = {toxinidir}/tests/functional
-commands = functest-run-suite --keep-faulty-model {posargs}
-deps = -r{toxinidir}/tests/functional/requirements.txt
+commands = functest-run-suite {posargs:--keep-faulty-model}
+deps = -r {toxinidir}/tests/functional/requirements.txt

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,3 +1,7 @@
 distro<1.7.0
 croniter
 pidfile
+# NOTE(rgildein): The contextvars could not be installed without this requirement to be specified.
+setuptools>=42
+# NOTE(rgildein): The typing-extensions could not be installed without this requirement to be specified.
+flit-core>=3


### PR DESCRIPTION
Using master branch for zaza with TEST_JUJU3=1 [1] and dropping
bootstack-actions for func in CI to be able to use specific lxd
channel.

Changing to use of Juju 3.4 controller for testing instead of Juju 3.1, using TEST_JUJU3=1 [1] for zaza to install proper libjuju version. 

Simply sanitation of project and add workflow concurrency to avoid running multiple workflows on a single PR. Like this if new commit arrived the previous run will be canceled by new run.

~~blocked until [#655](https://github.com/openstack-charmers/zaza/pull/655) is not merged~~

---
[1]:
https://github.com/openstack-charmers/zaza/commit/af7eea953dd5d74d3d074fe67b5765dca3911ca6