### PR TITLE
Pin pbr to fix install

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -5,3 +5,5 @@ pidfile
 setuptools>=42
 # NOTE(rgildein): The typing-extensions could not be installed without this requirement to be specified.
 flit-core>=3
+# NOTE: pbr 6.1.1 introduced a dependency on setuptools>=64, which is not available in the build environment constraints.
+pbr==6.1.0


### PR DESCRIPTION
On main, when this charm is newly built, it fails to install with:

```text
unit.duplicity/0.install Processing ./wheelhouse/pbr-6.1.1.tar.gz
unit.duplicity/0.install   Installing build dependencies: started
unit.duplicity/0.install   Installing build dependencies: finished with status 'error'
unit.duplicity/0.install   error: subprocess-exited-with-error
unit.duplicity/0.install
unit.duplicity/0.install   × pip subprocess to install build dependencies did not run successfully.
unit.duplicity/0.install   │ exit code: 1
unit.duplicity/0.install   ╰─> [4 lines of output]
unit.duplicity/0.install       Looking in links: wheelhouse
unit.duplicity/0.install       Ignoring setuptools: markers 'python_version < "3.7"' don't match your environment
unit.duplicity/0.install       ERROR: Could not find a version that satisfies the requirement setuptools>=64.0.0 (from versions: 59.6.0)
unit.duplicity/0.install       ERROR: No matching distribution found for setuptools>=64.0.0
unit.duplicity/0.install       [end of output]
```

See https://github.com/canonical/charm-duplicity/actions/runs/13210460023/job/36978020004 for an example test run where the install hook failed.

pbr release 6.1.1 added setuptools >= 64.0.0 as a build dependency. However, due to other constraints in the duplicity charm build (I'm not sure what),
the maximum version of setuptools available to install is 59.6.0.

So we can pin pbr to 6.1.0 as last known working revision.