### PR TITLE
Workaround indirect build issue for reactive charm [1]

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,7 +1,10 @@
 type: charm
 parts:
   charm:
-    source: src
+    source: .
+    source-subdir: src
+    build-environment:
+    - PIP_CONSTRAINT: $CRAFT_PART_BUILD_WORK/constraints.txt
     plugin: reactive
     build-snaps: [charm]
 platforms:

--- a/src/constraints.txt
+++ b/src/constraints.txt
@@ -1,0 +1,2 @@
+# See https://github.com/canonical/charmcraft/issues/2259#issuecomment-2842766428
+setuptools_scm < 8.2.0

--- a/src/constraints.txt
+++ b/src/constraints.txt
@@ -1,2 +1,2 @@
 # See https://github.com/canonical/charmcraft/issues/2259#issuecomment-2842766428
-setuptools_scm < 8.2.0
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,9 +1,3 @@
 distro<1.7.0
 croniter
 pidfile
-# NOTE(rgildein): The contextvars could not be installed without this requirement to be specified.
-setuptools>=42
-# NOTE(rgildein): The typing-extensions could not be installed without this requirement to be specified.
-flit-core>=3
-# NOTE: pbr 6.1.1 introduced a dependency on setuptools>=64, which is not available in the build environment constraints.
-pbr==6.1.0


### PR DESCRIPTION

This is the way charmcraft team suggest us to do, and they will not add workaround in charmcraft level (like they did for other plugins) since reactive plugin is unofficially deprecated, and they don't maintain it as well (the build process is in `charm` snap)

Workaround indirect build issue for reactive charm [1].

[1]: https://github.com/canonical/solutions-engineering-automation/issues/218
